### PR TITLE
[Jun Wu] #N/A fix: initial amount is incorrect when we don't check inventory at start date and existing movement items

### DIFF
--- a/app/src/main/java/org/openlmis/core/manager/MovementReasonManager.java
+++ b/app/src/main/java/org/openlmis/core/manager/MovementReasonManager.java
@@ -276,6 +276,10 @@ public final class MovementReasonManager {
           || this == MovementType.RECEIVE
           || (this == MovementType.ISSUE && MovementReasonManager.UNPACK_KIT.equalsIgnoreCase(movementReason));
     }
+
+    public boolean isInventoryType() {
+      return PHYSICAL_INVENTORY == this || INITIAL_INVENTORY == this;
+    }
   }
 
   @Data

--- a/app/src/main/java/org/openlmis/core/model/repository/RnrFormRepository.java
+++ b/app/src/main/java/org/openlmis/core/model/repository/RnrFormRepository.java
@@ -321,7 +321,7 @@ public class RnrFormRepository {
     return rnrFormItems;
   }
 
-  public Long getInitialAmountIfPeriodMovementItemsAreEmpty(
+  public Long getPreviousPeriodLastMovementItemSOH(
       StockCard stockCard,
       Date periodBegin
   ) {
@@ -475,7 +475,7 @@ public class RnrFormRepository {
         stockCard, notFullStockItemsByCreatedData, periodBegin
     );
 
-    if (notFullStockItemsByCreatedData == null || notFullStockItemsByCreatedData.isEmpty()) {
+    if (isStockMovementItemsEmpty(notFullStockItemsByCreatedData)) {
       rnrFormHelper.initRnrFormItemWithoutMovement(rnrFormItem, rnrFormItem.getInitialAmount());
     } else {
       rnrFormHelper.assignTotalValues(rnrFormItem, notFullStockItemsByCreatedData);
@@ -492,8 +492,10 @@ public class RnrFormRepository {
     RnrFormItem rnrFormItem = new RnrFormItem();
     // initialAmount
     Long initialAmount;
-    if (notFullStockItemsByCreatedData == null || notFullStockItemsByCreatedData.isEmpty()) {
-      initialAmount = getInitialAmountIfPeriodMovementItemsAreEmpty(stockCard, periodBegin);
+    if (isStockMovementItemsEmpty(notFullStockItemsByCreatedData)
+        || (!isInventoryType(notFullStockItemsByCreatedData.get(0).getMovementType()))
+    ) {
+      initialAmount = getPreviousPeriodLastMovementItemSOH(stockCard, periodBegin);
     } else {
       initialAmount = notFullStockItemsByCreatedData.get(0).getStockOnHand();
     }
@@ -502,6 +504,10 @@ public class RnrFormRepository {
     rnrFormItem.setProduct(stockCard.getProduct());
 
     return rnrFormItem;
+  }
+
+  private boolean isStockMovementItemsEmpty(List<StockMovementItem> notFullStockItemsByCreatedData) {
+    return notFullStockItemsByCreatedData == null || notFullStockItemsByCreatedData.isEmpty();
   }
 
   protected ArrayList<RnrFormItem> fillAllProducts(RnRForm form, List<RnrFormItem> basicItems)
@@ -526,7 +532,7 @@ public class RnrFormRepository {
 
       if (rnrFormItem.getInitialAmount() == null) {
         updateInitialAmount(
-            rnrFormItem, getInitialAmountIfPeriodMovementItemsAreEmpty(
+            rnrFormItem, getPreviousPeriodLastMovementItemSOH(
                 stockRepository.queryStockCardByProductId(product.getId()),
                 form.getPeriodBegin()
             ));

--- a/app/src/main/java/org/openlmis/core/model/repository/RnrFormRepository.java
+++ b/app/src/main/java/org/openlmis/core/model/repository/RnrFormRepository.java
@@ -27,8 +27,6 @@ import static org.openlmis.core.constant.FieldConstants.PROGRAM_ID;
 import static org.openlmis.core.constant.FieldConstants.STATUS;
 import static org.openlmis.core.constant.FieldConstants.SUBMITTED_TIME;
 import static org.openlmis.core.constant.FieldConstants.SYNCED;
-import static org.openlmis.core.manager.MovementReasonManager.MovementType.INITIAL_INVENTORY;
-import static org.openlmis.core.manager.MovementReasonManager.MovementType.PHYSICAL_INVENTORY;
 import static org.openlmis.core.utils.Constants.AL_PROGRAM_CODE;
 import static org.openlmis.core.utils.Constants.MMIA_PROGRAM_CODE;
 import static org.openlmis.core.utils.Constants.MMTB_PROGRAM_CODE;
@@ -396,7 +394,7 @@ public class RnrFormRepository {
   }
 
   private boolean isInventoryType(MovementType movementType) {
-    return PHYSICAL_INVENTORY == movementType || INITIAL_INVENTORY == movementType;
+    return movementType.isInventoryType();
   }
 
   @NonNull
@@ -493,7 +491,7 @@ public class RnrFormRepository {
     // initialAmount
     Long initialAmount;
     if (isStockMovementItemsEmpty(notFullStockItemsByCreatedData)
-        || (!isInventoryType(notFullStockItemsByCreatedData.get(0).getMovementType()))
+        || firstItemsTypeIsNotInventory(notFullStockItemsByCreatedData)
     ) {
       initialAmount = getPreviousPeriodLastMovementItemSOH(stockCard, periodBegin);
     } else {
@@ -504,6 +502,11 @@ public class RnrFormRepository {
     rnrFormItem.setProduct(stockCard.getProduct());
 
     return rnrFormItem;
+  }
+
+  private boolean firstItemsTypeIsNotInventory(List<StockMovementItem> notFullStockItemsByCreatedData) {
+    return notFullStockItemsByCreatedData != null && !notFullStockItemsByCreatedData.isEmpty()
+        && !isInventoryType(notFullStockItemsByCreatedData.get(0).getMovementType());
   }
 
   private boolean isStockMovementItemsEmpty(List<StockMovementItem> notFullStockItemsByCreatedData) {

--- a/app/src/main/java/org/openlmis/core/presenter/VIARequisitionPresenter.java
+++ b/app/src/main/java/org/openlmis/core/presenter/VIARequisitionPresenter.java
@@ -341,7 +341,7 @@ public class VIARequisitionPresenter extends BaseRequisitionPresenter {
         );
 
     Long initialAmount;
-    if (stockMovementItems == null || stockMovementItems.isEmpty()) {
+    if (isStockMovementItemsEmpty(stockMovementItems) || firstItemsTypeIsNotInventory(stockMovementItems)) {
       initialAmount = rnrFormRepository.getPreviousPeriodLastMovementItemSOH(stockCard, periodBegin);
     } else {
       initialAmount = stockMovementItems.get(0).getStockOnHand();
@@ -349,6 +349,15 @@ public class VIARequisitionPresenter extends BaseRequisitionPresenter {
     }
 
     rnrFormItem.setInitialAmount(initialAmount);
+  }
+
+  private boolean firstItemsTypeIsNotInventory(List<StockMovementItem> stockMovementItems) {
+    return stockMovementItems != null && !stockMovementItems.isEmpty()
+        && !stockMovementItems.get(0).getMovementType().isInventoryType();
+  }
+
+  private boolean isStockMovementItemsEmpty(List<StockMovementItem> stockMovementItems) {
+    return stockMovementItems == null || stockMovementItems.isEmpty();
   }
 
 

--- a/app/src/main/java/org/openlmis/core/presenter/VIARequisitionPresenter.java
+++ b/app/src/main/java/org/openlmis/core/presenter/VIARequisitionPresenter.java
@@ -342,7 +342,7 @@ public class VIARequisitionPresenter extends BaseRequisitionPresenter {
 
     Long initialAmount;
     if (stockMovementItems == null || stockMovementItems.isEmpty()) {
-      initialAmount = rnrFormRepository.getInitialAmountIfPeriodMovementItemsAreEmpty(stockCard, periodBegin);
+      initialAmount = rnrFormRepository.getPreviousPeriodLastMovementItemSOH(stockCard, periodBegin);
     } else {
       initialAmount = stockMovementItems.get(0).getStockOnHand();
       rnrFormHelper.assignTotalValues(rnrFormItem, stockMovementItems);


### PR DESCRIPTION
- fix: initial amount is incorrect when we don't check inventory at start date and existing movement items